### PR TITLE
Update PROS svg file for Safari / iOS

### DIFF
--- a/tokens/1/0x915424ac489433130d92b04096f3b96c82e92a9d/logo.svg
+++ b/tokens/1/0x915424ac489433130d92b04096f3b96c82e92a9d/logo.svg
@@ -10,7 +10,7 @@
         fill: #080808;
       }
     </style>
-    <radialGradient id="radial-gradient" cx="170.46" cy="202.04" fx="-86.02" fy="271.44" r="265.7" gradientTransform="translate(260.2 -129.24) rotate(44.94) scale(1 1.47)" gradientUnits="userSpaceOnUse">
+    <radialGradient id="radial-gradient" cx="170.46" cy="202.04" fx="-86" fy="271.44" r="265.7" gradientTransform="translate(260.2 -129.24) rotate(44.94) scale(1 1.47)" gradientUnits="userSpaceOnUse">
       <stop offset=".21" stop-color="#ebad5e"/>
       <stop offset=".59" stop-color="#78c193"/>
       <stop offset=".71" stop-color="#93c58f"/>

--- a/tokens/56/0x915424ac489433130d92b04096f3b96c82e92a9d/logo.svg
+++ b/tokens/56/0x915424ac489433130d92b04096f3b96c82e92a9d/logo.svg
@@ -10,7 +10,7 @@
         fill: #080808;
       }
     </style>
-    <radialGradient id="radial-gradient" cx="170.46" cy="202.04" fx="-86.02" fy="271.44" r="265.7" gradientTransform="translate(260.2 -129.24) rotate(44.94) scale(1 1.47)" gradientUnits="userSpaceOnUse">
+    <radialGradient id="radial-gradient" cx="170.46" cy="202.04" fx="-86" fy="271.44" r="265.7" gradientTransform="translate(260.2 -129.24) rotate(44.94) scale(1 1.47)" gradientUnits="userSpaceOnUse">
       <stop offset=".21" stop-color="#ebad5e"/>
       <stop offset=".59" stop-color="#78c193"/>
       <stop offset=".71" stop-color="#93c58f"/>

--- a/tokens/8453/0x915424ac489433130d92b04096f3b96c82e92a9d/logo.svg
+++ b/tokens/8453/0x915424ac489433130d92b04096f3b96c82e92a9d/logo.svg
@@ -10,7 +10,7 @@
         fill: #080808;
       }
     </style>
-    <radialGradient id="radial-gradient" cx="170.46" cy="202.04" fx="-86.02" fy="271.44" r="265.7" gradientTransform="translate(260.2 -129.24) rotate(44.94) scale(1 1.47)" gradientUnits="userSpaceOnUse">
+    <radialGradient id="radial-gradient" cx="170.46" cy="202.04" fx="-86" fy="271.44" r="265.7" gradientTransform="translate(260.2 -129.24) rotate(44.94) scale(1 1.47)" gradientUnits="userSpaceOnUse">
       <stop offset=".21" stop-color="#ebad5e"/>
       <stop offset=".59" stop-color="#78c193"/>
       <stop offset=".71" stop-color="#93c58f"/>


### PR DESCRIPTION
Please review the following token assets: [Just looking to make small fix to SVG file which doesn't display properly on Safari and iOS only]

## 📑 Description

<!-- Some basic information about the token you want to add -->

- Token Name: Prosper (PROS)
- Project Website:
  - https://www.prosper-fi.com/
  - https://docs.prosper-fi.com/other-resources/smart-contract-addresses
- Explorer URI:
  - https://bscscan.com/token/0x915424Ac489433130d92B04096F3b96c82e92a9D
  - https://etherscan.io/token/0x915424ac489433130d92b04096f3b96c82e92a9d
  - https://basescan.org/token/0x915424Ac489433130d92B04096F3b96c82e92a9D

---

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

-   [✅] I created a new folder with the token address (**all in lowercase** for EVM chains, **case sensitive** for Solana)
-   [✅] I added the token's logo as a `32x32` PNG file, named `logo-32.png`
-   [✅] I added the token's logo as a `128x128` PNG file, named `logo-128.png`
-   [✅] I added the token's logo as a SVG file, named `logo.svg`
-   [✅] My SVG logo is a proper SVG and does not contain base64 encoded elements
-   [✅] My documentation/website clearly display the token address
