### PR TITLE
Redirect assets through jsDelivr with GitHub raw fallback

### DIFF
--- a/.github/workflows/purge-jsdelivr.yml
+++ b/.github/workflows/purge-jsdelivr.yml
@@ -1,0 +1,30 @@
+name: Purge jsDelivr cache
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'tokens/**'
+      - 'chains/**'
+
+permissions:
+  contents: read
+
+jobs:
+  purge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      # jsDelivr refreshes @main mappings on its own within ~12h; purging the changed files makes
+      # freshly merged logos available immediately instead. A failed purge is non-fatal by design.
+      - name: Purge changed asset files
+        run: |
+          git diff --name-only --diff-filter=ACMR HEAD^ HEAD -- tokens chains | while IFS= read -r file; do
+            curl -fsS --max-time 10 "https://purge.jsdelivr.net/gh/SmolDapp/tokenAssets@main/${file}" > /dev/null \
+              || echo "purge failed for ${file} (self-heals within 12h)"
+            sleep 0.2
+          done

--- a/_config/goAPI/cdnFallback.go
+++ b/_config/goAPI/cdnFallback.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-co-op/gocron"
+)
+
+/**************************************************************************************************
+** jsDelivr is the primary redirect target: multi-CDN (Fastly + Cloudflare + Bunny) and 7-day
+** client cache headers, versus 5 minutes on raw.githubusercontent.com. GitHub raw stays as the
+** always-valid fallback: both serve the exact same files from the main branch, so switching
+** between them is safe at any moment.
+**************************************************************************************************/
+const JSDELIVR_BASE_URI = `https://cdn.jsdelivr.net/gh/SmolDapp/tokenAssets@main`
+const GITHUB_BASE_URI = `https://raw.githubusercontent.com/SmolDapp/tokenAssets/main`
+const HEALTH_CANARY_URI = JSDELIVR_BASE_URI + `/chains/1/logo-32.png`
+
+/**************************************************************************************************
+** Redirects carry a short client cache so the failover window stays bounded: health detection
+** (up to ~60s) plus this TTL is the worst case for a client to keep following a dead target.
+** The asset itself is cached 7 days by jsDelivr, so only this tiny 307 gets re-requested.
+**************************************************************************************************/
+const REDIRECT_CACHE_CONTROL = `public, max-age=300`
+
+var forceGithubRedirect = os.Getenv(`FORCE_GITHUB_CDN`) == `true`
+var jsDelivrHealthy atomic.Bool
+var healthCheckClient = &http.Client{Timeout: 5 * time.Second}
+
+/**************************************************************************************************
+** RedirectBaseURI returns the CDN base currently considered safe. The process starts on GitHub
+** (the long-standing behavior) and only promotes jsDelivr once the health loop has confirmed it.
+** Setting FORCE_GITHUB_CDN=true pins the legacy behavior without a code change.
+**************************************************************************************************/
+func RedirectBaseURI() string {
+	if forceGithubRedirect {
+		return GITHUB_BASE_URI
+	}
+	if jsDelivrHealthy.Load() {
+		return JSDELIVR_BASE_URI
+	}
+	return GITHUB_BASE_URI
+}
+
+func isJsDelivrUp() bool {
+	response, err := healthCheckClient.Get(HEALTH_CANARY_URI)
+	if err != nil {
+		return false
+	}
+	defer response.Body.Close()
+	return response.StatusCode == http.StatusOK
+}
+
+/**************************************************************************************************
+** cdnHealthLoop probes jsDelivr every 30 seconds. Two consecutive results in the same direction
+** flip the target, so a single network blip never flaps the CDN choice. Both targets serve
+** identical content, so a flip is always safe — only latency characteristics change.
+**************************************************************************************************/
+func cdnHealthLoop() {
+	consecutiveUp := 0
+	consecutiveDown := 0
+	probe := func() {
+		if isJsDelivrUp() {
+			consecutiveUp++
+			consecutiveDown = 0
+			if consecutiveUp >= 2 {
+				jsDelivrHealthy.Store(true)
+			}
+		} else {
+			consecutiveDown++
+			consecutiveUp = 0
+			if consecutiveDown >= 2 {
+				jsDelivrHealthy.Store(false)
+			}
+		}
+	}
+	probe()
+	scheduler := gocron.NewScheduler(time.UTC)
+	scheduler.Every(30).Seconds().Do(probe)
+	scheduler.StartAsync()
+}

--- a/_config/goAPI/main.go
+++ b/_config/goAPI/main.go
@@ -23,6 +23,7 @@ var originOfAccess = []string{}
 func main() {
 	fmt.Println("Starting SmolAssets API")
 	go accessLogger()
+	go cdnHealthLoop()
 	NewRouter().Run(`:8081`)
 }
 

--- a/_config/goAPI/serveChain.go
+++ b/_config/goAPI/serveChain.go
@@ -7,8 +7,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-const BASE_CHAIN_URI = `https://raw.githubusercontent.com/SmolDapp/tokenAssets/main`
-
 func ServeChain(c *gin.Context) {
 	chainIDStr := c.Param("chainID")
 	fileName := c.Param("filename")
@@ -18,7 +16,8 @@ func ServeChain(c *gin.Context) {
 		return
 	}
 
-	targetURL := fmt.Sprintf("%s/chains/%s/%s", BASE_CHAIN_URI, chainIDStr, fileName)
-	c.Redirect(http.StatusPermanentRedirect, targetURL)
+	targetURL := fmt.Sprintf("%s/chains/%s/%s", RedirectBaseURI(), chainIDStr, fileName)
+	c.Header(`Cache-Control`, REDIRECT_CACHE_CONTROL)
+	c.Redirect(http.StatusTemporaryRedirect, targetURL)
 	c.Abort()
 }

--- a/_config/goAPI/serveToken.go
+++ b/_config/goAPI/serveToken.go
@@ -8,12 +8,10 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-const BASE_TOKENS_URI = `https://raw.githubusercontent.com/SmolDapp/tokenAssets/main`
-
 func resolveNotFound(c *gin.Context) {
 	fallback := c.Query("fallback")
 	if fallback == "true" {
-		c.Redirect(http.StatusTemporaryRedirect, BASE_TOKENS_URI+`/_config/nodeAPI/public/not-found.png`)
+		c.Redirect(http.StatusTemporaryRedirect, RedirectBaseURI()+`/_config/nodeAPI/public/not-found.png`)
 		c.Abort()
 		return
 	}
@@ -40,7 +38,7 @@ func resolveNotFound(c *gin.Context) {
 func resolveGasToken(c *gin.Context) {
 	fallback := c.Query("fallback")
 	if fallback == "true" {
-		c.Redirect(http.StatusTemporaryRedirect, BASE_TOKENS_URI+`/_config/nodeAPI/public/gas-token.png`)
+		c.Redirect(http.StatusTemporaryRedirect, RedirectBaseURI()+`/_config/nodeAPI/public/gas-token.png`)
 		c.Abort()
 		return
 	}
@@ -82,7 +80,8 @@ func ServeToken(c *gin.Context) {
 		return
 	}
 
-	targetURL := fmt.Sprintf("%s/tokens/%s/%s/%s", BASE_TOKENS_URI, chainIDStr, tokenAddress, fileName)
-	c.Redirect(http.StatusPermanentRedirect, targetURL)
+	targetURL := fmt.Sprintf("%s/tokens/%s/%s/%s", RedirectBaseURI(), chainIDStr, tokenAddress, fileName)
+	c.Header(`Cache-Control`, REDIRECT_CACHE_CONTROL)
+	c.Redirect(http.StatusTemporaryRedirect, targetURL)
 	c.Abort()
 }

--- a/_config/goAPI/serveToken.go
+++ b/_config/goAPI/serveToken.go
@@ -16,20 +16,14 @@ func resolveNotFound(c *gin.Context) {
 		return
 	}
 
-	if fallback != "" {
-		resp, err := http.Get(fallback)
-		if err != nil {
-			c.String(http.StatusNotFound, "Not found")
-			return
-		}
-		defer resp.Body.Close()
-
-		contentType := resp.Header.Get("Content-Type")
-		if contentType != "" && strings.HasPrefix(contentType, "image/") {
-			fmt.Printf("Using fallback image for gas token: %s\n", fallback)
-			c.DataFromReader(http.StatusOK, resp.ContentLength, contentType, resp.Body, nil)
-			return
-		}
+	// A caller may point fallback at their own image URL. Redirect the browser to it instead of
+	// fetching it server-side: the daemon makes no arbitrary outbound request (no SSRF), and the
+	// image renders on its own origin, never ours. http(s) only, so the Location cannot carry a
+	// javascript: or data: scheme.
+	if strings.HasPrefix(fallback, "https://") || strings.HasPrefix(fallback, "http://") {
+		c.Redirect(http.StatusTemporaryRedirect, fallback)
+		c.Abort()
+		return
 	}
 
 	c.String(http.StatusNotFound, "Not found")
@@ -43,20 +37,14 @@ func resolveGasToken(c *gin.Context) {
 		return
 	}
 
-	if fallback != "" {
-		resp, err := http.Get(fallback)
-		if err != nil {
-			c.String(http.StatusNotFound, "Not found")
-			return
-		}
-		defer resp.Body.Close()
-
-		contentType := resp.Header.Get("Content-Type")
-		if contentType != "" && strings.HasPrefix(contentType, "image/") {
-			fmt.Printf("Using fallback image for gas token: %s\n", fallback)
-			c.DataFromReader(http.StatusOK, resp.ContentLength, contentType, resp.Body, nil)
-			return
-		}
+	// A caller may point fallback at their own image URL. Redirect the browser to it instead of
+	// fetching it server-side: the daemon makes no arbitrary outbound request (no SSRF), and the
+	// image renders on its own origin, never ours. http(s) only, so the Location cannot carry a
+	// javascript: or data: scheme.
+	if strings.HasPrefix(fallback, "https://") || strings.HasPrefix(fallback, "http://") {
+		c.Redirect(http.StatusTemporaryRedirect, fallback)
+		c.Abort()
+		return
 	}
 
 	c.String(http.StatusNotFound, "Not found")


### PR DESCRIPTION
## Summary
Implements CDN-based asset delivery through jsDelivr with automatic fallback to GitHub raw content. Fallback handling now uses HTTP redirects instead of server-side fetching, reducing server load. Adds a workflow to purge jsDelivr cache when needed.

## What changed
- Added cdnFallback.go with logic to redirect asset requests through jsDelivr
- Implemented GitHub raw content fallback for when jsDelivr is unavailable
- Changed fallback URL handling from server-side fetches to HTTP 302 redirects
- Added purge-jsdelivr.yml workflow for cache invalidation
- Refactored serveToken.go to remove server-side fallback fetching logic
- Updated serveChain.go to wire in the new CDN fallback handler

## Risks
- Clients must support following HTTP redirects; some integrations may fail if they don't
- jsDelivr availability becomes a critical dependency; outages require GitHub fallback
- CDN caching may delay propagation of updated assets
- External redirects could add latency for some geographic regions

## Test plan
- Verify assets return proper 302 redirects to jsDelivr URLs
- Test fallback redirect chain resolves to GitHub raw content
- Simulate jsDelivr unavailability and confirm fallback is triggered
- Verify the purge-jsdelivr workflow successfully clears CDN cache
- Monitor asset delivery latency and redirect chain resolution
- Test with various HTTP clients to ensure redirect handling is reliable

## Docs impact
Documentation should be updated to explain the new CDN redirect behavior, fallback mechanism, and how to manually trigger cache purges via the new workflow.

## Breaking changes
Fallback asset delivery now uses HTTP redirects instead of server-side fetching. Clients that don't follow redirects will fail to retrieve assets through the fallback path.