### PR TITLE
feat: edit an existing token from the submit form

### DIFF
--- a/_config/ui/.env.example
+++ b/_config/ui/.env.example
@@ -11,3 +11,9 @@ AUTH_SECRET=
 # authored by them — point this at a throwaway repo while testing.
 GITHUB_SUBMIT_REPO=SmolDapp/tokenAssets
 GITHUB_SUBMIT_BASE=main
+
+# Same repo and branch, exposed to the browser: the edit form reads the current info.json from there to
+# prefill and to work out which fields a submission would remove. Keep them in sync with the two above,
+# or an edit will diff against a different tree than the one it writes to.
+NEXT_PUBLIC_GITHUB_SUBMIT_REPO=SmolDapp/tokenAssets
+NEXT_PUBLIC_GITHUB_SUBMIT_BASE=main

--- a/_config/ui/app/_components/Submit/SubmitForm.tsx
+++ b/_config/ui/app/_components/Submit/SubmitForm.tsx
@@ -8,23 +8,57 @@ import {Input} from '@components/ui/input';
 import {useTokens} from '@hooks/useTokens';
 import ArrowDown from '@icons/arrow-down.svg';
 import {DEFAULT_CHAIN} from '@utils/constants';
+import type {TTokenInfo} from '@utils/infoJson';
 import {canFetchOnchain, fetchOnchainToken} from '@utils/onchainToken';
+import {fetchTokenPrefill} from '@utils/tokenPrefill';
 import {
 	isValidAddress,
+	parseTags,
+	type TErasableField,
 	type TSubmissionInput,
 	type TValidationError,
+	type TValidationScope,
+	toFolderAddress,
 	validateSubmission,
+	validateTags,
 	validateTokenMeta
 } from '@utils/tokenSubmission';
 import {useRouter} from 'next/navigation';
 import {signIn} from 'next-auth/react';
 import type {ReactElement, ReactNode} from 'react';
-import {useEffect, useMemo, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 
 type TMetaStatus = 'idle' | 'loading' | 'ready' | 'error' | 'unsupported';
+type TPrefillStatus = 'idle' | 'loading' | 'ready' | 'error';
+// Set from a route answer that contradicts the local token list, and cleared as soon as the address or
+// chain changes.
+type TForcedMode = 'edit' | 'create' | null;
+
+// What survives the GitHub sign-in redirect, stashed in sessionStorage just before signIn().
+type TStash = {
+	chainID: string;
+	address: string;
+	svgText: string;
+	svgFileName: string;
+	name: string;
+	symbol: string;
+	decimals: string;
+	description: string;
+	website: string;
+	tagsRaw: string;
+};
+
+const ERASABLE_FIELDS: TErasableField[] = ['website', 'description', 'tags'];
 
 const inputClassName = 'border border-white/15 bg-white/5 text-white placeholder:text-white/30 focus:border-white/40';
 const STASH_KEY = 'token-submit-stash';
+
+// Identifies the token whose values are in the form. Keyed on the folder the submission would write to,
+// like every other "same token" decision here, so re-pasting an address in a different case is not
+// mistaken for a different token.
+function prefillKey(chainID: string, address: string): string {
+	return `${chainID}/${toFolderAddress(address)}`;
+}
 
 const labelClassName = 'block font-medium font-mono text-white/50 text-xs uppercase tracking-[0.1em]';
 
@@ -86,16 +120,64 @@ export function SubmitForm({
 	const [submitError, setSubmitError] = useState('');
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [prURL, setPrURL] = useState<string | null>(null);
+	const [baseInfo, setBaseInfo] = useState<TTokenInfo | null>(null);
+	const [baseSvgText, setBaseSvgText] = useState('');
+	const [prefillStatus, setPrefillStatus] = useState<TPrefillStatus>('idle');
+	const [prefillNonce, setPrefillNonce] = useState(0);
+	const [confirmErasure, setConfirmErasure] = useState(false);
+	const [forcedMode, setForcedMode] = useState<TForcedMode>(null);
+	// `<chainID>/<address>` of the token whose values are already in the form, so the prefill applies
+	// once and never overwrites what the user typed.
+	const appliedPrefillKeyRef = useRef('');
 
 	// Cross-checked against the same per-chain token list the browse pages use, so a submission
 	// for an address already in the CDN is caught before the user fills out the rest of the form.
-	const {findToken} = useTokens(chainID);
+	// Matched on the folder the submission would write to, not on a lowercased address: a Solana
+	// address typed in a different case resolves to a different folder and is genuinely new.
+	const {findByFolderAddress, isLoading: isTokenListLoading, hasError: hasTokenListError} = useTokens(chainID);
 	const existingToken = useMemo(() => {
 		if (!isValidAddress(chainID, address)) {
 			return undefined;
 		}
-		return findToken(address.trim());
-	}, [findToken, chainID, address]);
+		return findByFolderAddress(address.trim());
+	}, [findByFolderAddress, chainID, address]);
+
+	// The token list starts empty and fills in asynchronously, so "no match" is only meaningful once it
+	// has loaded. Without this the form flickers through the add state on a token that does exist.
+	//
+	// That list is a build-time snapshot while the route resolves existence against GitHub live, so the
+	// two can disagree — a token merged since the last index refresh, or a folder deleted from main. The
+	// route's answer wins: it sets `forcedMode` and the form switches instead of dead-ending on a status
+	// the user has no way to act on.
+	let isEditing = Boolean(existingToken) && !isTokenListLoading && !hasTokenListError;
+	if (forcedMode === 'edit') {
+		isEditing = true;
+	}
+	if (forcedMode === 'create') {
+		isEditing = false;
+	}
+	// name/symbol/decimals are carried over from the base file untouched, so they are neither shown
+	// nor re-validated. That also keeps the tokens whose symbol or name predates the current rules
+	// editable instead of permanently stuck.
+	const metaLocked = isEditing && baseInfo !== null;
+
+	// Fields that hold a value on disk and would be written away by this submission. An edit replaces
+	// the whole file, so removing them is legitimate — but it has to be confirmed rather than happen as
+	// a side effect of a collapsed accordion.
+	const erasures = useMemo(() => {
+		if (!isEditing || !baseInfo) {
+			return [];
+		}
+		return ERASABLE_FIELDS.filter(field => {
+			if (field === 'website') {
+				return Boolean(baseInfo.website) && !website.trim();
+			}
+			if (field === 'description') {
+				return Boolean(baseInfo.description) && !description.trim();
+			}
+			return Boolean(baseInfo.tags?.length) && parseTags(tagsRaw).length === 0;
+		});
+	}, [isEditing, baseInfo, website, description, tagsRaw]);
 
 	const svgDataURL = useMemo(() => {
 		if (!svgText) {
@@ -103,6 +185,84 @@ export function SubmitForm({
 		}
 		return `data:image/svg+xml,${encodeURIComponent(svgText)}`;
 	}, [svgText]);
+
+	// Read the token's current metadata and logo as soon as the address resolves to something already on
+	// the CDN, and fill the form with them: an edit rewrites the whole file, so the form has to start
+	// from what is on disk or submitting would wipe every field the user did not retype. A 404 on
+	// info.json is a normal answer (some folders have logos only); anything else must surface as an error,
+	// because an empty form standing in for a failed read looks exactly like a deliberate erasure.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: prefillNonce is an intentional re-run trigger for the Retry button, not read inside the effect.
+	useEffect(() => {
+		// A mode forced by the route is authoritative and does not wait on the local list. Otherwise
+		// "not in the list" only means something once the list has actually loaded — bailing out while it
+		// is in flight is also what lets values restored from the sign-in stash survive the mount.
+		if (forcedMode !== 'edit') {
+			if (isTokenListLoading || hasTokenListError) {
+				return;
+			}
+			if (!existingToken) {
+				appliedPrefillKeyRef.current = '';
+				setBaseInfo(null);
+				setBaseSvgText('');
+				setPrefillStatus('idle');
+				setConfirmErasure(false);
+				return;
+			}
+		}
+		let cancelled = false;
+		setPrefillStatus('loading');
+		fetchTokenPrefill(chainID, address.trim())
+			.then(prefill => {
+				if (cancelled) {
+					return;
+				}
+				setBaseInfo(prefill.info);
+				setBaseSvgText(prefill.svgText);
+				setPrefillStatus('ready');
+				// Applied once per token: re-running on every render would fight the user's typing, and
+				// the sign-in restore claims this key first so it is not overwritten either.
+				const key = prefillKey(chainID, address);
+				if (appliedPrefillKeyRef.current === key) {
+					return;
+				}
+				appliedPrefillKeyRef.current = key;
+				setWebsite(prefill.info?.website || '');
+				setDescription(prefill.info?.description || '');
+				setTagsRaw((prefill.info?.tags || []).join(', '));
+				setSvgText(prefill.svgText);
+				setSvgError('');
+				setErrors([]);
+				// Belongs to the token that was just left, not to this one: going straight from one
+				// existing token to another would otherwise carry a ticked confirmation across.
+				setConfirmErasure(false);
+				let fileName = '';
+				if (prefill.svgText) {
+					fileName = 'Current logo';
+				}
+				setSvgFileName(fileName);
+				// Description and tags sit behind a collapsed accordion; leaving it shut would hide the
+				// very values this submission is about to rewrite.
+				if (prefill.info?.description || prefill.info?.tags?.length) {
+					setShowOptional(true);
+				}
+			})
+			.catch(() => {
+				if (cancelled) {
+					return;
+				}
+				setPrefillStatus('error');
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [existingToken, isTokenListLoading, hasTokenListError, forcedMode, chainID, address, prefillNonce]);
+
+	// A forced mode belongs to one address on one chain. Editing either invalidates it, so the form goes
+	// back to trusting the local token list.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: clearing on address/chain change is the point; forcedMode is written here, not read.
+	useEffect(() => {
+		setForcedMode(null);
+	}, [chainID, address]);
 
 	// Auto-read name/symbol/decimals whenever the address or chain changes. Debounced and race-safe:
 	// a newer address/chain cancels the in-flight result so stale metadata never lands.
@@ -224,7 +384,7 @@ export function SubmitForm({
 		}
 		sessionStorage.removeItem(STASH_KEY);
 		try {
-			const stash = JSON.parse(raw) as Record<string, string>;
+			const stash = JSON.parse(raw) as Partial<TStash>;
 			setChainID(stash.chainID || DEFAULT_CHAIN.id);
 			setAddress(stash.address || '');
 			setSvgText(stash.svgText || '');
@@ -235,6 +395,12 @@ export function SubmitForm({
 			setDescription(stash.description || '');
 			setWebsite(stash.website || '');
 			setTagsRaw(stash.tagsRaw || '');
+			// Claim the prefill key for the token being restored. Without this the prefill resolves a
+			// moment later on a fresh mount, finds an unclaimed ref, and overwrites everything the user
+			// typed before being sent to GitHub — silently, and the submission then has nothing to change.
+			if (stash.address) {
+				appliedPrefillKeyRef.current = prefillKey(stash.chainID || DEFAULT_CHAIN.id, stash.address);
+			}
 		} catch {
 			// ignore a corrupt stash
 		}
@@ -282,10 +448,20 @@ export function SubmitForm({
 	}
 
 	async function handleSubmit(): Promise<void> {
-		if (existingToken) {
-			return;
+		// An unchanged logo is never re-sent: rewriting an identical SVG would also re-rasterize both
+		// PNGs, putting three no-op files in the diff. Compared on the trimmed form because that is what
+		// the server writes, so a stored file differing only by trailing whitespace still counts as equal.
+		let svgToSend = svgText;
+		if (isEditing && svgText.trim() === baseSvgText.trim()) {
+			svgToSend = '';
 		}
-		const validationErrors = validateSubmission(currentInput());
+		const input: TSubmissionInput = {...currentInput(), svgText: svgToSend};
+		const scope: TValidationScope = {
+			requireLogo: !isEditing,
+			requireWebsite: !isEditing,
+			requireMeta: !metaLocked
+		};
+		const validationErrors = [...validateSubmission(input, scope), ...validateTags(parseTags(tagsRaw))];
 		setErrors(validationErrors);
 		if (validationErrors.length > 0) {
 			return;
@@ -304,17 +480,36 @@ export function SubmitForm({
 				body: JSON.stringify({
 					chainID,
 					address: address.trim(),
-					svg: svgText,
+					svg: svgToSend,
 					name,
 					symbol,
 					decimals,
 					description,
 					website,
-					tags: tagsRaw
+					tags: tagsRaw,
+					// Absent for a new token, which keeps the add-only contract — and its 409 — intact.
+					isEdit: isEditing
 				})
 			});
 			const data = (await response.json()) as {error?: string; prUrl?: string};
 			if (!response.ok) {
+				// The route resolves existence against the live repo; the local token list is a snapshot.
+				// When they disagree, switch the form to what the route says instead of leaving the user
+				// on a status they cannot act on. The prefill then reloads for the new mode.
+				if (response.status === 409 && !isEditing) {
+					setForcedMode('edit');
+					setSubmitError(
+						'This token is already on the CDN — switched to editing it. Review and submit again.'
+					);
+					return;
+				}
+				if (response.status === 404 && isEditing) {
+					setForcedMode('create');
+					setSubmitError(
+						'This token is not on the CDN yet — switched to adding it. Review and submit again.'
+					);
+					return;
+				}
 				setSubmitError(data.error || 'Submission failed — please try again.');
 				return;
 			}
@@ -344,6 +539,11 @@ export function SubmitForm({
 		setShowOptional(false);
 		setErrors([]);
 		setSubmitError('');
+		setBaseInfo(null);
+		setBaseSvgText('');
+		setPrefillStatus('idle');
+		setConfirmErasure(false);
+		setForcedMode(null);
 	}
 
 	// name/symbol/decimals must pass the same checks the submission does, whether they were typed
@@ -352,12 +552,26 @@ export function SubmitForm({
 	const metaFieldsValid = validateTokenMeta(name, symbol, decimals).length === 0;
 	// Show the editable metadata fields when the chain has no RPC, OR when an on-chain read
 	// succeeded but returned values that don't pass validation (pre-filled, so the user can fix).
-	const showManualFields = metaStatus === 'unsupported' || (metaStatus === 'ready' && !metaFieldsValid);
-	const metaReady = (metaStatus === 'ready' || metaStatus === 'unsupported') && metaFieldsValid;
+	// Never in an edit that has a base file to carry those three fields over from.
+	const showManualFields =
+		!metaLocked && (metaStatus === 'unsupported' || (metaStatus === 'ready' && !metaFieldsValid));
+	const metaReady = metaLocked || ((metaStatus === 'ready' || metaStatus === 'unsupported') && metaFieldsValid);
+	const needsErasureConfirm = erasures.length > 0 && !confirmErasure;
 
 	// The submit button is the single status surface (fixed size → no layout shift):
 	// disabled until everything is present, a spinner while reading the chain or opening the PR.
-	const canSubmit = metaReady && !existingToken && svgText.length > 0 && website.trim().length > 0;
+	// An edit needs no project link (the vast majority of tokens on disk have none) but does need the
+	// logo the prefill loaded, so that submitting never blanks it.
+	let canSubmit = metaReady && svgText.length > 0 && website.trim().length > 0;
+	if (isEditing) {
+		canSubmit = metaReady && prefillStatus === 'ready' && !needsErasureConfirm && svgText.length > 0;
+	}
+	// Without the list there is no way to tell an addition from an edit, and guessing "addition" would
+	// send the user into a 409 with nothing to act on. `hasError` is sticky per chain, so a reload is the
+	// way out — say so rather than failing at submit time.
+	if (hasTokenListError && forcedMode === null) {
+		canSubmit = false;
+	}
 	const isBusy = isSubmitting || metaStatus === 'loading';
 
 	let submitContent: ReactNode = 'Open pull request →';
@@ -367,10 +581,22 @@ export function SubmitForm({
 				<span className={'sr-only'}>{isSubmitting ? 'Submitting…' : 'Reading token metadata…'}</span>
 			</span>
 		);
+	} else if (hasTokenListError && forcedMode === null) {
+		submitContent = 'Token list unavailable — reload';
+	} else if (isEditing && prefillStatus === 'error') {
+		submitContent = 'Could not read this token';
+	} else if (isEditing && prefillStatus !== 'ready') {
+		submitContent = 'Reading current details…';
+	} else if (isEditing && needsErasureConfirm) {
+		submitContent = 'Confirm the removal';
+	} else if (isEditing && !svgText) {
+		submitContent = 'Add a logo';
+	} else if (isEditing && !signedIn) {
+		submitContent = 'Sign in with GitHub →';
+	} else if (isEditing) {
+		submitContent = 'Update this token →';
 	} else if (metaStatus === 'error') {
 		submitContent = 'Token not readable';
-	} else if ((metaStatus === 'ready' || metaStatus === 'unsupported') && existingToken) {
-		submitContent = 'Token already exists';
 	} else if (showManualFields && !metaFieldsValid) {
 		submitContent = 'Fill in the token details';
 	} else if (metaReady && !svgText) {
@@ -412,7 +638,35 @@ export function SubmitForm({
 					/>
 				</Field>
 
-				{metaStatus === 'error' && (
+				{isEditing && (
+					<div className={'space-y-1.5 rounded-sm border border-white/20 bg-white/5 p-4'}>
+						<p className={'font-mono text-white/70 text-xs leading-relaxed'}>
+							{'This token is already on the CDN, you are editing it.'}
+						</p>
+						{prefillStatus === 'loading' && (
+							<p className={'font-mono text-white/40 text-xxs'}>{'Reading its current details…'}</p>
+						)}
+						{prefillStatus === 'error' && (
+							<div
+								role={'alert'}
+								className={'flex items-center justify-between gap-2'}>
+								<p className={'font-mono text-error text-xxs leading-relaxed'}>
+									{'Could not read its current details — editing is disabled until it loads.'}
+								</p>
+								<button
+									type={'button'}
+									onClick={() => setPrefillNonce(nonce => nonce + 1)}
+									className={
+										'shrink-0 font-mono text-white/70 text-xxs underline underline-offset-4 hover:text-white'
+									}>
+									{'Retry'}
+								</button>
+							</div>
+						)}
+					</div>
+				)}
+
+				{metaStatus === 'error' && !metaLocked && (
 					<div
 						className={
 							'flex items-center justify-between gap-2 rounded-sm border border-error/40 bg-error/10 p-3'
@@ -578,6 +832,25 @@ export function SubmitForm({
 						</div>
 					)}
 				</div>
+
+				{erasures.length > 0 && (
+					<div className={'space-y-2 rounded-sm border border-white/25 bg-white/5 p-3'}>
+						<p className={'font-mono text-white/70 text-xs leading-relaxed'}>
+							{`This submission removes ${erasures.join(', ')} from the token.`}
+						</p>
+						<label className={'flex cursor-pointer items-center gap-2'}>
+							<input
+								type={'checkbox'}
+								checked={confirmErasure}
+								onChange={() => setConfirmErasure(value => !value)}
+								className={'size-3.5 rounded-sm border-white/30 bg-white/5 text-white'}
+							/>
+							<span className={'font-mono text-white/50 text-xxs uppercase tracking-[0.1em]'}>
+								{'Remove them'}
+							</span>
+						</label>
+					</div>
+				)}
 
 				{errors.length > 0 && (
 					<div

--- a/_config/ui/app/_hooks/useTokens.ts
+++ b/_config/ui/app/_hooks/useTokens.ts
@@ -3,6 +3,7 @@
 import {CHAINS} from '@utils/constants';
 import {isNewToken} from '@utils/helpers';
 import {rankBySearchScore} from '@utils/searchScore';
+import {toFolderAddress} from '@utils/tokenSubmission';
 import type {TToken} from '@utils/types';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 
@@ -80,6 +81,7 @@ type TUseTokensResult = {
 	hasNextPage: boolean;
 	fetchNextPage: () => void;
 	findToken: (address: string) => TToken | undefined;
+	findByFolderAddress: (address: string) => TToken | undefined;
 };
 
 export function useTokens(chainID: string, searchQuery = ''): TUseTokensResult {
@@ -162,12 +164,25 @@ export function useTokens(chainID: string, searchQuery = ''): TUseTokensResult {
 		[allTokens]
 	);
 
+	// Matches on the folder the submission would actually write to, so it is case-sensitive for Solana
+	// and lowercased for EVM. findToken lowercases both sides, which means a base58 address typed in a
+	// different case matches an existing token there while resolving to a different — new — folder.
+	// Anything that decides "this token exists" before writing must use this one.
+	const findByFolderAddress = useCallback(
+		(address: string): TToken | undefined => {
+			const folderAddress = toFolderAddress(address);
+			return allTokens.find(token => toFolderAddress(token.address) === folderAddress);
+		},
+		[allTokens]
+	);
+
 	return {
 		tokens: visibleTokens,
 		isLoading,
 		hasError,
 		hasNextPage: visibleCount < filteredTokens.length,
 		fetchNextPage,
-		findToken
+		findToken,
+		findByFolderAddress
 	};
 }

--- a/_config/ui/app/_utils/constants.ts
+++ b/_config/ui/app/_utils/constants.ts
@@ -36,6 +36,13 @@ export const DEFAULT_CHAIN: TChainInfo = CHAINS.find(chain => chain.slug === 'et
 export const SITE_URI = 'https://tokens.smold.app';
 export const ASSETS_BASE_URI = 'https://assets.smold.app';
 export const GITHUB_URI = 'https://github.com/SmolDapp/tokenAssets';
+// Read straight from the repo because the assets CDN does not serve info.json. Must resolve to the same
+// repo and branch the submit route writes to (GITHUB_SUBMIT_REPO / GITHUB_SUBMIT_BASE): the form shows
+// and diffs against what it reads here, so pointing the two at different trees would make an edit erase
+// fields it never displayed. Read on the client, hence the NEXT_PUBLIC_ twins.
+const SUBMIT_REPO = process.env.NEXT_PUBLIC_GITHUB_SUBMIT_REPO || 'SmolDapp/tokenAssets';
+const SUBMIT_BASE = process.env.NEXT_PUBLIC_GITHUB_SUBMIT_BASE || 'main';
+export const GITHUB_RAW_TOKENS_URI = `https://raw.githubusercontent.com/${SUBMIT_REPO}/${SUBMIT_BASE}/tokens`;
 export const SMOLD_APP_URI = 'https://smold.app';
 export const BRAND_GREEN = '#123524';
 

--- a/_config/ui/app/_utils/githubRepo.server.ts
+++ b/_config/ui/app/_utils/githubRepo.server.ts
@@ -1,0 +1,56 @@
+// Reads the live state of a token folder on the base repo. The submit route needs this because the
+// deployment root is _config/ui: the tokens/ tree is not on the server filesystem, and the committed
+// public/data snapshot it used to rely on is a build-time artefact that can lag behind main.
+
+import type {Octokit} from '@octokit/core';
+
+type TFolderEntry = {
+	name: string;
+	sha: string;
+};
+
+type THttpError = {
+	status?: number;
+};
+
+// Returns null when the folder does not exist on `ref` — that is the authoritative "this token is new"
+// answer, on the exact case-sensitive path the PR will write to.
+export async function readFolderEntries(
+	octokit: Octokit,
+	owner: string,
+	repo: string,
+	ref: string,
+	folder: string
+): Promise<TFolderEntry[] | null> {
+	try {
+		const response = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
+			owner,
+			repo,
+			path: folder,
+			ref
+		});
+		if (!Array.isArray(response.data)) {
+			return null;
+		}
+		return response.data.map(entry => {
+			return {name: entry.name, sha: entry.sha};
+		});
+	} catch (error) {
+		if ((error as THttpError).status === 404) {
+			return null;
+		}
+		throw error;
+	}
+}
+
+// Read by blob sha rather than by path: a blob sha is immutable, so there is no caching ambiguity
+// between the listing above and the content fetched here.
+export async function readBlobText(octokit: Octokit, owner: string, repo: string, sha: string): Promise<string> {
+	const response = await octokit.request('GET /repos/{owner}/{repo}/git/blobs/{file_sha}', {
+		owner,
+		repo,
+		// biome-ignore lint/style/useNamingConvention: GitHub's REST parameter name, not ours.
+		file_sha: sha
+	});
+	return Buffer.from(response.data.content, 'base64').toString('utf8');
+}

--- a/_config/ui/app/_utils/infoJson.ts
+++ b/_config/ui/app/_utils/infoJson.ts
@@ -1,0 +1,129 @@
+// Reads and writes the on-disk info.json of a token. It holds ONLY non-derivable data: address,
+// chainID and logoURI come from the folder path, so they are never stored in it.
+
+import type {TSubmissionInput} from '@utils/tokenSubmission';
+
+export type TTokenInfo = {
+	name: string;
+	symbol: string;
+	decimals: number;
+	description?: string;
+	website?: string;
+	tags?: string[];
+};
+
+const ALLOWED_INFO_KEYS = new Set(['name', 'symbol', 'decimals', 'description', 'website', 'tags']);
+
+// Builds a TTokenInfo from raw form values. Empty optionals are omitted, not written as blanks.
+function infoFromInput(input: TSubmissionInput, tags: string[]): TTokenInfo {
+	const info: TTokenInfo = {
+		name: input.name.trim(),
+		symbol: input.symbol.trim(),
+		decimals: Number(input.decimals)
+	};
+	const description = input.description.trim();
+	if (description) {
+		info.description = description;
+	}
+	const website = input.website.trim();
+	if (website) {
+		info.website = website;
+	}
+	if (tags.length > 0) {
+		info.tags = tags;
+	}
+	return info;
+}
+
+// The single serializer. Key order and the trailing newline are load-bearing: every info.json on disk
+// round-trips through this byte for byte, which is what keeps an edit to one field a one-line diff
+// instead of a whole-file rewrite.
+export function serializeInfoJson(info: TTokenInfo): string {
+	const ordered: TTokenInfo = {
+		name: info.name,
+		symbol: info.symbol,
+		decimals: info.decimals
+	};
+	if (info.description) {
+		ordered.description = info.description;
+	}
+	if (info.website) {
+		ordered.website = info.website;
+	}
+	if (info.tags && info.tags.length > 0) {
+		ordered.tags = info.tags;
+	}
+	return `${JSON.stringify(ordered, null, 2)}\n`;
+}
+
+// Strict mirror of the schema enforced by .github/scripts/verify-tokens.mjs and the inline VALIDATE_SCRIPT
+// in .github/workflows/verify-fork.yml — KEEP ALL THREE COPIES IN SYNC.
+// Returns null on anything it does not fully model, including an unknown key. Rejecting rather than
+// dropping matters: re-serializing a file whose keys we don't carry would silently erase them.
+export function parseInfoJson(raw: string): TTokenInfo | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return null;
+	}
+	if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+		return null;
+	}
+	const record = parsed as Record<string, unknown>;
+	for (const key of Object.keys(record)) {
+		if (!ALLOWED_INFO_KEYS.has(key)) {
+			return null;
+		}
+	}
+	const {name, symbol, decimals, description, website, tags} = record;
+	if (typeof name !== 'string' || !name || typeof symbol !== 'string' || !symbol) {
+		return null;
+	}
+	if (typeof decimals !== 'number' || !Number.isInteger(decimals) || decimals < 0) {
+		return null;
+	}
+	const info: TTokenInfo = {name, symbol, decimals};
+	if (description !== undefined) {
+		if (typeof description !== 'string') {
+			return null;
+		}
+		info.description = description;
+	}
+	if (website !== undefined) {
+		if (typeof website !== 'string') {
+			return null;
+		}
+		info.website = website;
+	}
+	if (tags !== undefined) {
+		if (!Array.isArray(tags) || tags.some(tag => typeof tag !== 'string')) {
+			return null;
+		}
+		info.tags = tags as string[];
+	}
+	return info;
+}
+
+type TMergeParams = {
+	base: TTokenInfo | null;
+	input: TSubmissionInput;
+	tags: string[];
+};
+
+// Produces the info.json an edit writes. An edit always replaces the whole file, so every optional
+// field comes from the request — leaving one empty removes it. Only name/symbol/decimals are carried
+// over from the base: they are on-chain truth and not editable through this form, and taking them from
+// the file rather than from the request is what makes that lock real instead of cosmetic.
+export function mergeTokenInfo({base, input, tags}: TMergeParams): TTokenInfo {
+	const replacement = infoFromInput(input, tags);
+	if (!base) {
+		return replacement;
+	}
+	return {
+		...replacement,
+		name: base.name,
+		symbol: base.symbol,
+		decimals: base.decimals
+	};
+}

--- a/_config/ui/app/_utils/tokenPrefill.ts
+++ b/_config/ui/app/_utils/tokenPrefill.ts
@@ -1,0 +1,43 @@
+// Reads a token's current metadata and logo so the submit form can show what is on disk before editing
+// it. The logo CDN does not serve info.json, so this reads the repo directly — raw.githubusercontent
+// sends access-control-allow-origin: *, which is what lets the browser do it without a proxy route.
+
+import {GITHUB_RAW_TOKENS_URI} from '@utils/constants';
+import {parseInfoJson, type TTokenInfo} from '@utils/infoJson';
+import {toFolderAddress} from '@utils/tokenSubmission';
+
+export type TTokenPrefill = {
+	// null for the token folders that carry logos but no info.json — a normal case, not a failure.
+	info: TTokenInfo | null;
+	// Empty when the current logo could not be read: the form then asks for a new one rather than
+	// pretending the token has none.
+	svgText: string;
+};
+
+export async function fetchTokenPrefill(chainID: string, address: string): Promise<TTokenPrefill> {
+	const folder = `${GITHUB_RAW_TOKENS_URI}/${chainID}/${toFolderAddress(address)}`;
+	const [infoResponse, svgResponse] = await Promise.all([
+		fetch(`${folder}/info.json`, {cache: 'no-store'}),
+		fetch(`${folder}/logo.svg`, {cache: 'no-store'})
+	]);
+
+	let svgText = '';
+	if (svgResponse.ok) {
+		svgText = await svgResponse.text();
+	}
+
+	if (infoResponse.status === 404) {
+		return {info: null, svgText};
+	}
+	// Anything other than "present" or "genuinely absent" has to throw: an empty form that silently
+	// stood in for a failed read would look exactly like a deliberate erasure.
+	if (!infoResponse.ok) {
+		throw new Error(`Could not read info.json (${infoResponse.status})`);
+	}
+
+	const info = parseInfoJson(await infoResponse.text());
+	if (!info) {
+		throw new Error('info.json has a field this form cannot edit');
+	}
+	return {info, svgText};
+}

--- a/_config/ui/app/_utils/tokenPrefill.ts
+++ b/_config/ui/app/_utils/tokenPrefill.ts
@@ -4,7 +4,9 @@
 
 import {GITHUB_RAW_TOKENS_URI} from '@utils/constants';
 import {parseInfoJson, type TTokenInfo} from '@utils/infoJson';
-import {toFolderAddress} from '@utils/tokenSubmission';
+import {isValidAddress, toFolderAddress} from '@utils/tokenSubmission';
+
+const PATH_SEGMENT_RE = /^[a-zA-Z0-9]+$/;
 
 export type TTokenPrefill = {
 	// null for the token folders that carry logos but no info.json — a normal case, not a failure.
@@ -15,7 +17,19 @@ export type TTokenPrefill = {
 };
 
 export async function fetchTokenPrefill(chainID: string, address: string): Promise<TTokenPrefill> {
-	const folder = `${GITHUB_RAW_TOKENS_URI}/${chainID}/${toFolderAddress(address)}`;
+	if (!isValidAddress(chainID, address)) {
+		throw new Error('Invalid address');
+	}
+	// Checked on the exact strings that get interpolated, not on what they derive from: both must be a
+	// single alphanumeric path segment, so neither can carry a "/" or a ".." that would walk the request
+	// out of this repo's tokens folder. The current caller already constrains them; this keeps that true
+	// for the next one.
+	const folderAddress = toFolderAddress(address);
+	if (!PATH_SEGMENT_RE.test(chainID) || !PATH_SEGMENT_RE.test(folderAddress)) {
+		throw new Error('Invalid token reference');
+	}
+
+	const folder = `${GITHUB_RAW_TOKENS_URI}/${chainID}/${folderAddress}`;
 	const [infoResponse, svgResponse] = await Promise.all([
 		fetch(`${folder}/info.json`, {cache: 'no-store'}),
 		fetch(`${folder}/logo.svg`, {cache: 'no-store'})

--- a/_config/ui/app/_utils/tokenSubmission.ts
+++ b/_config/ui/app/_utils/tokenSubmission.ts
@@ -1,5 +1,5 @@
-// Builds and validates a token submission. The on-disk info.json holds ONLY non-derivable data:
-// address / chainID / logoURI come from the folder path, so they are never stored here.
+// Builds and validates a token submission. Reading and writing the resulting info.json lives in
+// infoJson.ts.
 
 import {isForbiddenSvg} from '@utils/svgSafety';
 
@@ -37,15 +37,6 @@ function isValidSolanaAddress(value: string): boolean {
 	return base58Decode(value)?.length === 32;
 }
 
-export type TTokenInfo = {
-	name: string;
-	symbol: string;
-	decimals: number;
-	description?: string;
-	website?: string;
-	tags?: string[];
-};
-
 export type TSubmissionInput = {
 	chainID: string;
 	address: string;
@@ -58,9 +49,29 @@ export type TSubmissionInput = {
 };
 
 export type TValidationError = {
-	field: 'address' | 'svg' | 'name' | 'symbol' | 'decimals' | 'website';
+	field: 'address' | 'svg' | 'name' | 'symbol' | 'decimals' | 'website' | 'description' | 'tags';
 	message: string;
 };
+
+// The optional info.json fields, i.e. the ones an edit can leave empty and thereby remove.
+export type TErasableField = 'website' | 'description' | 'tags';
+
+// The three requirements that differ between adding a token and editing one, kept independent because
+// they genuinely vary independently: an edit never has to bring a logo, the vast majority of tokens on
+// disk have no website at all, and some carry a name or symbol that predates the current rules
+// (e.g. the symbol "yvCurve-stETH-frxETH-f"). Re-validating those on edit would make them uneditable.
+export type TValidationScope = {
+	requireLogo: boolean;
+	requireWebsite: boolean;
+	requireMeta: boolean;
+};
+
+const CREATE_SCOPE: TValidationScope = {requireLogo: true, requireWebsite: true, requireMeta: true};
+
+const MAX_DESCRIPTION = 2000;
+const MAX_TAGS = 10;
+const MAX_TAG_LENGTH = 32;
+const TAG_RE = /^[a-z0-9][a-z0-9 -]*$/;
 
 export function isNonEvmChain(chainID: string): boolean {
 	return NON_EVM_CHAINS.has(chainID);
@@ -123,56 +134,70 @@ export function validateTokenMeta(name: string, symbol: string, decimals: string
 	return errors;
 }
 
-export function validateSubmission(input: TSubmissionInput): TValidationError[] {
+export function validateSubmission(
+	input: TSubmissionInput,
+	scope: TValidationScope = CREATE_SCOPE
+): TValidationError[] {
 	const errors: TValidationError[] = [];
 
 	if (!isValidAddress(input.chainID, input.address)) {
 		errors.push({field: 'address', message: 'Enter a valid contract address for the selected chain'});
 	}
-	if (!input.svgText.includes('<svg')) {
-		errors.push({field: 'svg', message: 'Upload the token logo as an SVG file'});
-	} else if (isForbiddenSvg(input.svgText)) {
-		errors.push({
-			field: 'svg',
-			message: 'The SVG must be a pure vector — no scripts, event handlers, external links or embedded rasters.'
-		});
-	} else if (new TextEncoder().encode(input.svgText).length > 153_600) {
-		// Byte length (not UTF-16 code units) so client, server and the CI's `wc -c` cap agree:
-		// a multibyte SVG under 153,600 code units can still exceed 150KB on disk.
-		errors.push({field: 'svg', message: 'The SVG must be under 150KB'});
+	// An edit that leaves the logo alone sends no SVG at all. One that does send an SVG faces exactly
+	// the same checks as a new submission.
+	if (scope.requireLogo || input.svgText.length > 0) {
+		if (!input.svgText.includes('<svg')) {
+			errors.push({field: 'svg', message: 'Upload the token logo as an SVG file'});
+		} else if (isForbiddenSvg(input.svgText)) {
+			errors.push({
+				field: 'svg',
+				message:
+					'The SVG must be a pure vector — no scripts, event handlers, external links or embedded rasters.'
+			});
+		} else if (new TextEncoder().encode(input.svgText).length > 153_600) {
+			// Byte length (not UTF-16 code units) so client, server and the CI's `wc -c` cap agree:
+			// a multibyte SVG under 153,600 code units can still exceed 150KB on disk.
+			errors.push({field: 'svg', message: 'The SVG must be under 150KB'});
+		}
 	}
 
-	errors.push(...validateTokenMeta(input.name, input.symbol, input.decimals));
+	// Skipped when editing a token that already has an info.json: name/symbol/decimals are carried over
+	// from that file untouched, so re-checking the values the client echoed back would reject the tokens
+	// on disk whose symbol or name predates the current rules.
+	if (scope.requireMeta) {
+		errors.push(...validateTokenMeta(input.name, input.symbol, input.decimals));
+	}
 
 	const website = input.website.trim();
-	if (!website) {
+	if (scope.requireWebsite && !website) {
 		errors.push({field: 'website', message: 'A project link is required.'});
-	} else if (!/^https?:\/\//i.test(website)) {
+	} else if (website && !/^https?:\/\//i.test(website)) {
 		errors.push({field: 'website', message: 'Project link must start with http:// or https://.'});
-	} else if (/\s/.test(website)) {
+	} else if (website && /\s/.test(website)) {
 		errors.push({field: 'website', message: 'Project link cannot contain spaces.'});
+	}
+
+	// Free text is bounded because description and tags flow into a public repo and into every
+	// downstream consumer of info.json.
+	if (input.description.trim().length > MAX_DESCRIPTION) {
+		errors.push({field: 'description', message: `Description must be ${MAX_DESCRIPTION} characters or fewer`});
 	}
 
 	return errors;
 }
 
-// Assumes the input already passed validateSubmission. Empty optionals are omitted, not written as blanks.
-export function buildInfoJson(input: TSubmissionInput, tags: string[]): string {
-	const info: TTokenInfo = {
-		name: input.name.trim(),
-		symbol: input.symbol.trim(),
-		decimals: Number(input.decimals)
-	};
-	const description = input.description.trim();
-	if (description) {
-		info.description = description;
+// Tags are parsed before they can be counted, so this is separate from validateSubmission. parseTags
+// has already trimmed and lowercased them, hence the lowercase-only character set. Spaces are allowed
+// because tags on disk use them.
+export function validateTags(tags: string[]): TValidationError[] {
+	if (tags.length > MAX_TAGS) {
+		return [{field: 'tags', message: `Use ${MAX_TAGS} tags or fewer`}];
 	}
-	const website = input.website.trim();
-	if (website) {
-		info.website = website;
+	if (tags.some(tag => tag.length > MAX_TAG_LENGTH)) {
+		return [{field: 'tags', message: `Each tag must be ${MAX_TAG_LENGTH} characters or fewer`}];
 	}
-	if (tags.length > 0) {
-		info.tags = tags;
+	if (tags.some(tag => !TAG_RE.test(tag))) {
+		return [{field: 'tags', message: 'Tags may only use letters, numbers, spaces and hyphens'}];
 	}
-	return `${JSON.stringify(info, null, 2)}\n`;
+	return [];
 }

--- a/_config/ui/app/api/submit/route.ts
+++ b/_config/ui/app/api/submit/route.ts
@@ -1,14 +1,17 @@
 import {Octokit} from '@octokit/core';
 import {CHAINS} from '@utils/constants';
+import {readBlobText, readFolderEntries} from '@utils/githubRepo.server';
+import {mergeTokenInfo, parseInfoJson, serializeInfoJson, type TTokenInfo} from '@utils/infoJson';
 import {isSquareEnough, renderPngBase64} from '@utils/svgRaster.server';
 import {
-	buildInfoJson,
+	isValidAddress,
 	parseTags,
 	type TSubmissionInput,
+	type TValidationScope,
 	toFolderAddress,
-	validateSubmission
+	validateSubmission,
+	validateTags
 } from '@utils/tokenSubmission';
-import {findToken} from '@utils/tokens.server';
 import {NextResponse} from 'next/server';
 import {getToken} from 'next-auth/jwt';
 import {createPullRequest} from 'octokit-plugin-create-pull-request';
@@ -44,6 +47,26 @@ function isRateLimited(ip: string): boolean {
 	return recent.length > RATE_MAX;
 }
 
+// A label reaches the PR title, the commit message and the branch name. On an edit it comes from the
+// file on disk, which predates the current validation rules, so it is not bound by them — and even a
+// validated symbol may carry backticks or brackets that break out of a markdown code span.
+function safeLabel(value: string, fallback: string): string {
+	const cleaned = value.trim().replace(/[^A-Za-z0-9._+-]/g, '');
+	if (!cleaned) {
+		return fallback;
+	}
+	return cleaned.slice(0, 32);
+}
+
+// The project link is validated for scheme and whitespace but not for markdown. Left as-is it can close
+// its own autolink and render an arbitrary link next to it, which is exactly what a reviewer reads.
+function safeURL(value: string): string {
+	return value
+		.trim()
+		.replace(/[<>`[\]()*_~|\\]/g, '')
+		.slice(0, 200);
+}
+
 type TSubmitBody = {
 	chainID?: string;
 	address?: string;
@@ -54,6 +77,9 @@ type TSubmitBody = {
 	description?: string;
 	website?: string;
 	tags?: string;
+	// True only when the caller means to edit a token that already exists. Absent means "add a new
+	// token", which keeps the old contract — and the old 409 — intact for every existing caller.
+	isEdit?: boolean;
 };
 
 export async function POST(request: Request): Promise<Response> {
@@ -102,41 +128,38 @@ export async function POST(request: Request): Promise<Response> {
 	if (!chain) {
 		return NextResponse.json({error: 'Unsupported chain.'}, {status: 400});
 	}
-	const validationErrors = validateSubmission(input);
+
+	// Checked before the address is used to build any path: the strict form is what stops a "/" or a
+	// backtick from injecting a folder or markdown further down.
+	if (!isValidAddress(input.chainID, input.address)) {
+		return NextResponse.json({error: 'Enter a valid contract address for the selected chain'}, {status: 400});
+	}
+
+	const isEdit = body.isEdit === true;
+	const svg = `${input.svgText.trim()}\n`;
+	const hasNewLogo = input.svgText.length > 0;
+	const folderAddress = toFolderAddress(input.address);
+	const folder = `tokens/${input.chainID}/${folderAddress}`;
+
+	// An edit brings a logo only when it replaces one, never brings a project link for the many tokens
+	// that have none, and carries name/symbol/decimals over from the base file untouched. Taking the flag
+	// from the body is safe here because it only relaxes requirements: the folder cross-check below still
+	// decides whether this really is an edit, so a caller cannot use it to slip a new token through.
+	const scope: TValidationScope = {
+		requireLogo: !isEdit,
+		requireWebsite: !isEdit,
+		requireMeta: !isEdit
+	};
+	const tags = parseTags(body.tags || '');
+	const validationErrors = [...validateSubmission(input, scope), ...validateTags(tags)];
 	if (validationErrors.length > 0) {
 		return NextResponse.json({error: validationErrors[0].message}, {status: 400});
 	}
 
-	const svg = `${input.svgText.trim()}\n`;
-	const folderAddress = toFolderAddress(input.address);
-	// Reject addresses already in the CDN before opening a PR — mirrors the client-side guard so a
-	// direct API call (bypassing the disabled button) can't open a duplicate-address PR either.
-	if (findToken(input.chainID, folderAddress)) {
-		return NextResponse.json({error: 'This token already exists in the CDN.'}, {status: 409});
-	}
-	const folder = `tokens/${input.chainID}/${folderAddress}`;
-	const infoJson = buildInfoJson(input, parseTags(body.tags || ''));
-	const label = input.symbol.trim() || input.address;
-
-	// Explorer links so a reviewer can eyeball the token + check the contract is verified in one click.
-	let explorerLine = '- **Explorer:** not available for this chain';
-	if (chain.explorer) {
-		explorerLine = `- **Explorer:** [token page](${chain.explorer}/token/${input.address}) · [contract code](${chain.explorer}/address/${input.address}#code)`;
-	}
-
-	let png32 = '';
-	let png128 = '';
-	try {
-		if (!isSquareEnough(svg)) {
-			return NextResponse.json({error: 'The logo must be roughly square.'}, {status: 400});
-		}
-		png32 = renderPngBase64(svg, 32);
-		png128 = renderPngBase64(svg, 128);
-	} catch {
-		return NextResponse.json({error: 'Could not rasterize the SVG to PNG.'}, {status: 400});
-	}
-
 	const [owner, repoName] = repo.split('/');
+	if (!owner || !repoName) {
+		return NextResponse.json({error: 'Server misconfiguration: invalid GITHUB_SUBMIT_REPO.'}, {status: 500});
+	}
 	const octokit = new SubmitOctokit({auth: token});
 
 	// Pre-flight scope check. Opening the PR forks the repo and writes a branch (createRef); when the
@@ -165,6 +188,123 @@ export async function POST(request: Request): Promise<Response> {
 		);
 	}
 
+	// Existence is resolved against the live base repo, not against public/data/tokens/<id>.json: that
+	// snapshot is committed at build time, so a token merged since the last deploy is invisible to it —
+	// and writing a path that already exists updates it silently. Asking GitHub also compares the exact
+	// case-sensitive folder, which is what a Solana address in a different case would otherwise slip past.
+	let entries: Awaited<ReturnType<typeof readFolderEntries>>;
+	try {
+		entries = await readFolderEntries(octokit, owner, repoName, base, folder);
+	} catch {
+		return NextResponse.json({error: 'Could not read the token from GitHub — try again.'}, {status: 502});
+	}
+	const folderExists = entries !== null;
+
+	if (!isEdit && folderExists) {
+		return NextResponse.json({error: 'This token already exists in the CDN.'}, {status: 409});
+	}
+	if (isEdit && !folderExists) {
+		return NextResponse.json(
+			{error: 'This token is not on the CDN yet — submit it as a new token.'},
+			{status: 404}
+		);
+	}
+
+	// name/symbol/decimals come from the file on disk rather than from the request, so a crafted POST
+	// cannot rename a token. A folder with no info.json has nothing to take them from, which would leave
+	// the request as the only source — so an edit is refused there, exactly as it is when the file cannot
+	// be parsed. Those folders are still reachable through a hand-written pull request.
+	let baseInfo: TTokenInfo | null = null;
+	if (isEdit) {
+		const infoEntry = entries?.find(entry => entry.name === 'info.json');
+		if (!infoEntry) {
+			return NextResponse.json(
+				{error: 'This token has no info.json yet — open a pull request manually to add one.'},
+				{status: 400}
+			);
+		}
+		let baseRaw: string;
+		try {
+			baseRaw = await readBlobText(octokit, owner, repoName, infoEntry.sha);
+		} catch {
+			return NextResponse.json({error: 'Could not read the token from GitHub — try again.'}, {status: 502});
+		}
+		baseInfo = parseInfoJson(baseRaw);
+		if (!baseInfo) {
+			return NextResponse.json(
+				{error: "This token's info.json has a field this form cannot edit — open a pull request manually."},
+				{status: 400}
+			);
+		}
+	}
+
+	const info = mergeTokenInfo({base: baseInfo, input, tags});
+	const infoJson = serializeInfoJson(info);
+	const label = safeLabel(info.symbol, input.address);
+
+	// Explorer links so a reviewer can eyeball the token + check the contract is verified in one click.
+	let explorerLine = '- **Explorer:** not available for this chain';
+	if (chain.explorer) {
+		explorerLine = `- **Explorer:** [token page](${chain.explorer}/token/${input.address}) · [contract code](${chain.explorer}/address/${input.address}#code)`;
+	}
+
+	// Skipped entirely when the edit keeps the current logo: feeding an empty string to resvg would throw
+	// and surface as a misleading "could not rasterize". logo.svg is never written without both PNGs,
+	// because the CI requires all three logo files together in a folder.
+	let png32 = '';
+	let png128 = '';
+	if (hasNewLogo) {
+		try {
+			if (!isSquareEnough(svg)) {
+				return NextResponse.json({error: 'The logo must be roughly square.'}, {status: 400});
+			}
+			png32 = renderPngBase64(svg, 32);
+			png128 = renderPngBase64(svg, 128);
+		} catch {
+			return NextResponse.json({error: 'Could not rasterize the SVG to PNG.'}, {status: 400});
+		}
+	}
+
+	const files: Record<string, string | {content: string; encoding: 'base64'}> = {
+		[`${folder}/info.json`]: infoJson
+	};
+	if (hasNewLogo) {
+		files[`${folder}/logo.svg`] = svg;
+		files[`${folder}/logo-32.png`] = {content: png32, encoding: 'base64'};
+		files[`${folder}/logo-128.png`] = {content: png128, encoding: 'base64'};
+	}
+
+	let intro = 'Submitted via the Token Assets submit form.';
+	let title = `Add ${label} on ${chain.name}`;
+	let commit = `feat: add ${label} on ${chain.name}`;
+	let branchPrefix = 'submit';
+	let bodyLines = [
+		`- **Chain:** ${chain.name} (\`${input.chainID}\`)`,
+		`- **Address:** \`${input.address}\``,
+		`- **Symbol:** ${safeLabel(input.symbol, '?')} · **Decimals:** ${input.decimals}`,
+		`- **Project:** <${safeURL(input.website)}>`
+	];
+	if (isEdit) {
+		intro = 'Edited via the Token Assets submit form.';
+		title = `Update ${label} on ${chain.name}`;
+		commit = `chore: update ${label} on ${chain.name}`;
+		branchPrefix = 'edit';
+		// An edit prints no field value. description legitimately contains newlines and markdown lists,
+		// so interpolating it would let a submission forge extra body lines — a fake "- **Address:**"
+		// above the real one, for instance. The diff shows the values anyway.
+		let logoLine = '- **Logo:** unchanged';
+		if (hasNewLogo) {
+			logoLine = '- **Logo:** replaced';
+		}
+		bodyLines = [
+			`- **Chain:** ${chain.name} (\`${input.chainID}\`)`,
+			`- **Address:** \`${input.address}\``,
+			`- **Folder:** \`${folder}\``,
+			logoLine
+		];
+	}
+	bodyLines.push(explorerLine);
+
 	try {
 		const pr = await octokit.createPullRequest({
 			owner,
@@ -173,33 +313,24 @@ export async function POST(request: Request): Promise<Response> {
 			// directly — no fork, so no createRef-on-fork `repo`-scope escalation. Contributors WITHOUT push
 			// are still auto-forked by the plugin, so their PR still comes from their own fork.
 			forceFork: false,
-			title: `Add ${label} on ${chain.name}`,
-			body: [
-				'Submitted via the Token Assets submit form.',
-				'',
-				`- **Chain:** ${chain.name} (\`${input.chainID}\`)`,
-				`- **Address:** \`${input.address}\``,
-				`- **Symbol:** ${input.symbol} · **Decimals:** ${input.decimals}`,
-				`- **Project:** <${input.website.trim()}>`,
-				explorerLine
-			].join('\n'),
+			title,
+			body: [intro, '', ...bodyLines].join('\n'),
 			base,
-			head: `submit/${input.chainID}-${folderAddress}-${Date.now()}`,
+			// Without this the plugin happily commits an unchanged tree, pushes a branch and opens a PR
+			// with an empty diff. Submitting an edit without changing anything is the most likely accident
+			// in this flow, so it has to fail before any ref is written.
+			createWhenEmpty: false,
+			head: `${branchPrefix}/${input.chainID}-${folderAddress}-${Date.now()}`,
 			changes: [
 				{
-					commit: `feat: add ${label} on ${chain.name}`,
-					files: {
-						[`${folder}/logo.svg`]: svg,
-						[`${folder}/logo-32.png`]: {content: png32, encoding: 'base64'},
-						[`${folder}/logo-128.png`]: {content: png128, encoding: 'base64'},
-						[`${folder}/info.json`]: infoJson
-					}
+					commit,
+					files
 				}
 			]
 		});
 		const url = pr?.data?.html_url;
 		if (!url) {
-			return NextResponse.json({error: 'No changes to submit — this token may already exist.'}, {status: 409});
+			return NextResponse.json({error: 'No changes to submit.'}, {status: 409});
 		}
 		return NextResponse.json({prUrl: url});
 	} catch (error) {

--- a/_config/ui/styles/style.css
+++ b/_config/ui/styles/style.css
@@ -53,6 +53,7 @@ select:-webkit-autofill,
 select:-webkit-autofill:hover,
 select:-webkit-autofill:focus {
 	-webkit-box-shadow: 0 0 0px 1000px rgba(0, 0, 0, 0) inset;
+	-webkit-text-fill-color: #ffffff;
 	transition: background-color 5000s ease-in-out 0s;
 }
 input::-webkit-outer-spin-button,


### PR DESCRIPTION
## Why

`/submit` could only **add** a token. An address already on the CDN blocked the form ("Token already exists") and `POST /api/submit` answered `409`. Fixing an outdated logo, a dead project link or a wrong description meant opening a pull request by hand.

The repo side already accepted modifications — `verify-fork.yml` lets fork PRs "add **or modify**" under `tokens/`, and `purge-jsdelivr.yml` uses `--diff-filter=ACMR`. Only the app had no path to it.

## What changed

Detection is automatic: an address already on the CDN switches the form to editing, prefilled with the current `info.json` and logo. There is no mode picker — an edit rewrites the whole file, so clearing an optional field removes it. That removal is confirmed explicitly before it can happen.

The logo is only re-sent when it actually differs, so an edit that touches metadata alone produces a PR containing just `info.json`.

## Design note: the merge happens server-side

The client sends its values; the route reads the current `info.json` from the **live base repo** and merges there.

This is not incidental. `octokit-plugin-create-pull-request` builds its tree against the live tip of `main` at submit time. Had the client echoed back the fields it did not change — read up to 5 minutes earlier through `raw.githubusercontent`'s cache — a concurrent change would have been reverted cleanly: no conflict, a plausible-looking one-line diff, no signal for the reviewer.

It also makes the `name`/`symbol`/`decimals` lock real rather than cosmetic. Those three come from the file on disk, never from the request, so a crafted POST cannot rename a token. `readOnly` in the DOM is worth nothing to `curl`, and a one-line `"name"` diff is exactly the kind of thing that slips through review.

Editing is **refused** on the folders that carry logos but no `info.json`, since there would be nothing to take those three fields from — same answer the route already gives when the file cannot be parsed. Those folders remain reachable through a hand-written PR.

## Pre-existing bugs fixed on this path

- **`createWhenEmpty: false`.** The option was never passed, so a byte-identical submission committed an unchanged tree, pushed a branch and opened a PR with an empty diff. Submitting an edit without changing anything is the most likely accident in this flow.
- **Existence resolved against the live repo** instead of the build-time `public/data/tokens/<id>.json` snapshot. A token merged since the last deploy was invisible to that snapshot, and writing a path that already exists updates it silently.
- **Addresses compared through `toFolderAddress`.** `findToken` lowercased both sides while the folder is case-sensitive for base58, so a Solana address in a different case matched an existing token but resolved to a new folder.

## Hardening

`safeLabel()` / `safeURL()` sanitize everything reaching the PR title, commit message, branch name and body. On an edit, `symbol` comes from a file that predates the current validation rules, so it was bound by nothing. Free text is now bounded: description ≤ 2000 characters, ≤ 10 tags of ≤ 32 characters each, restricted charset.

The edit PR body names which fields changed but prints no field value — `description` legitimately contains newlines and markdown lists, which would let a submission forge extra body lines.

## Structure

`info.json` reading and writing moves to `_utils/infoJson.ts`, bringing `tokenSubmission.ts` back under 300 lines.

**All 4283 `info.json` files in the repo round-trip through the serializer byte for byte** (same key order, same 2-space indent, same trailing newline), so an edit to one field produces a one-line diff rather than a whole-file rewrite.

## Verification

`tsc --noEmit` clean, `biome lint` clean on the touched files, `bun run build` passes. The pure logic was exercised against the real corpus — round-trip, merge table, validation scopes, folder-address casing, tag bounds.

**Not verified:** the browser walkthrough, and an end-to-end PR (that needs GitHub auth and would open a real PR). Worth confirming before merge: a throwaway fork PR touching only an `info.json` should pass every `verify-fork.yml` step — reading the workflow says it does, since the three-logo-files check iterates `find ./tokens` over the merged tree rather than the diff.

## Note

Carries an earlier unpushed commit, `fix: keep autofilled input text white` — same page: Chrome's `-webkit-text-fill-color` overrode `color: white` on autofilled inputs, so the project link rendered black.
