### PR TITLE
fix: let an edit re-submit a text logo that is already on the CDN

### DIFF
--- a/_config/ui/app/_components/Submit/SubmitForm.tsx
+++ b/_config/ui/app/_components/Submit/SubmitForm.tsx
@@ -10,6 +10,7 @@ import ArrowDown from '@icons/arrow-down.svg';
 import {DEFAULT_CHAIN} from '@utils/constants';
 import type {TTokenInfo} from '@utils/infoJson';
 import {canFetchOnchain, fetchOnchainToken} from '@utils/onchainToken';
+import {containsTextElement} from '@utils/svgSafety';
 import {fetchTokenPrefill} from '@utils/tokenPrefill';
 import {
 	isValidAddress,
@@ -451,8 +452,12 @@ export function SubmitForm({
 		// An unchanged logo is never re-sent: rewriting an identical SVG would also re-rasterize both
 		// PNGs, putting three no-op files in the diff. Compared on the trimmed form because that is what
 		// the server writes, so a stored file differing only by trailing whitespace still counts as equal.
+		//
+		// Equal input no longer means equal output though: the route outlines `<text>` to paths, so
+		// re-sending the bytes already on the CDN is what converts a text logo. Skipping that would leave
+		// every existing one unfixable from this form.
 		let svgToSend = svgText;
-		if (isEditing && svgText.trim() === baseSvgText.trim()) {
+		if (isEditing && svgText.trim() === baseSvgText.trim() && !containsTextElement(svgText)) {
 			svgToSend = '';
 		}
 		const input: TSubmissionInput = {...currentInput(), svgText: svgToSend};

--- a/_config/ui/app/_utils/svgSafety.ts
+++ b/_config/ui/app/_utils/svgSafety.ts
@@ -12,3 +12,13 @@ const FORBIDDEN_SVG_PATTERN =
 export function isForbiddenSvg(svg: string): boolean {
 	return FORBIDDEN_SVG_PATTERN.test(svg);
 }
+
+// Mirrors the detection in svgRaster.server.ts, which cannot be imported here: it pulls in resvg, a
+// native server-only package. Kept in this module because both the client and the server need it.
+const TEXT_ELEMENT_PATTERN = /<(text|tspan)[\s>]/i;
+
+// The submit route outlines `<text>` to paths, so an SVG containing text is never committed as-is —
+// re-submitting the exact bytes already on the CDN still produces a different file.
+export function containsTextElement(svg: string): boolean {
+	return TEXT_ELEMENT_PATTERN.test(svg);
+}


### PR DESCRIPTION
## The bug

Pasting a token's own `logo.svg` into the edit form reports **nothing to change**, so an existing `<text>` logo cannot be converted through the UI.

Reproduced with the Sonic vS logo — pasting its exact current CDN bytes does nothing.

`SubmitForm.tsx:456`:

```ts
if (isEditing && svgText.trim() === baseSvgText.trim()) {
  svgToSend = '';
}
```

`baseSvgText` is the prefill, i.e. the `logo.svg` currently on the CDN. Pasting that file back is byte-identical, so the branch fires, `svgToSend` becomes `''`, `hasNewLogo` is false, no logo files are written, and `createWhenEmpty: false` in the route means no PR is opened.

That short-circuit was correct until #1336: identical input implied identical output. Now the route outlines `<text>` to paths, so **the same input produces a different committed file** — and re-submitting the stored bytes is precisely how a text logo gets converted.

Net effect: every `<text>` logo already on the CDN was unreachable from the form. The tokens the outlining was built to fix were the ones it could not reach.

## The fix

Treat an SVG containing text as always-changed while editing.

```ts
if (isEditing && svgText.trim() === baseSvgText.trim() && !containsTextElement(svgText)) {
```

The client cannot compute the outlined form to compare outputs directly — resvg is a native server-only package — but it does not need to: the presence of `<text>` is sufficient to know the server will rewrite it.

`containsTextElement` lives in `svgSafety.ts`, the module both client and server already share for SVG inspection, since `svgRaster.server.ts` cannot be imported into a client component.

## Verification

The four cases through the actual predicate:

| pasted | stored | result |
|---|---|---|
| `<text>` logo, identical | `<text>` | **sent to server** ← was blocked |
| already outlined, identical | outlined | `''` (no-op, unchanged behaviour) |
| `<text>` logo | outlined | sent |
| outlined | `<text>` | sent |

Row 2 is the one that matters for regressions: re-pasting an already-outlined logo still short-circuits, so this does not reintroduce no-op three-file diffs.

`tsc --noEmit` clean, `next build --webpack` compiles.

## Note

`biome check` reports pre-existing formatting diffs in `SubmitForm.tsx` (JSX at lines 80, 619, 633, 655) that are already present on `main` and untouched here. Not reformatted, to keep this diff to the two lines that matter.
